### PR TITLE
Use musl version to remove dependency on GLIBC

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -58,7 +58,7 @@ get_platform() {
       plat='apple-darwin'
       ;;
     linux)
-      plat='unknown-linux-gnu'
+      plat='unknown-linux-musl'
       ;;
     windows)
       plat='pc-windows=msvc'


### PR DESCRIPTION
I have a NAS which has an older version of GLIBC (2.21) which is not supported by the `gnu` build of delta. On the other hand, the statically linked `musl` build works just fine, so I'd like to propose using that one instead.