### PR TITLE
Install musl version instead of gnu

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -58,7 +58,7 @@ get_platform() {
       plat='apple-darwin'
       ;;
     linux)
-      plat='unknown-linux-gnu'
+      plat='unknown-linux-musl'
       ;;
     windows)
       plat='pc-windows=msvc'


### PR DESCRIPTION
This allows using delta on systems locked on older glibc versions.