### PR TITLE
Use musl version to remove dependency on GLIBC

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -58,7 +58,7 @@ get_platform() {
       plat='apple-darwin'
       ;;
     linux)
-      plat='unknown-linux-gnu'
+      plat='unknown-linux-musl'
       ;;
     windows)
       plat='pc-windows=msvc'


### PR DESCRIPTION
This change allows the delta package to be used on systems which have an outdated GLIBC, such as a QNAP NAS.