### PR TITLE
filter non-version tags

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -20,7 +20,8 @@ sort_versions() {
 
 list_github_tags() {
   git ls-remote --tags --refs "$GH_REPO" |
-    grep -o 'refs/tags/.*' | cut -d/ -f3- |
+    grep -o 'refs/tags/[0-9v].*' |
+    cut -d/ -f3- |
     sed 's/^v//'
 }
 


### PR DESCRIPTION
There is a tag, `windows-strip-binary` which always sorts as `latest`. This filters the list of tags, looking for ones that begin with a `v` or number.